### PR TITLE
Typescript support.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,50 @@
+interface ConnectedCallback {
+  (name: string, version: string): void;
+}
+interface Exception {
+  readonly name: string;
+  readonly dwException: string;
+  readonly dwSendID: number;
+  readonly dwIndex: number;
+  readonly cbData: string;
+}
+type RequestDataObject = [variableName: string, units: string | null, dataType?: number];
+interface Data { [key:string]: number | undefined }
+
+
+export function open(
+  appname: string,
+  connectedCallback: ConnectedCallback,
+  simExitedCallback: () => void,
+  exceptionCallback: (exception: Exception) => void,
+  errorCallback: (error: unknown) => void
+): boolean;
+
+export function requestDataOnSimObject(
+  reqData: RequestDataObject[] | number,
+  callback: (data: Data) => void,
+  objectId: number,
+  period: number,
+  dataRequestFlag: number
+): void
+
+export function requestDataOnSimObjectType(
+  reqData: RequestDataObject[] | number,
+  callback: (data: Data) => void,
+  radius: number,
+  simobjectType: number
+): void
+
+export function createDataDefinition(
+  reqData: RequestDataObject[],
+): number;
+
+export function setDataOnSimObject(
+  variableName: string,
+  unit: string | null,
+  value: unknown
+): void;
+
+export function subscribeToSystemEvent(eventName: string, callback: (data: unknown) => void): void;
+
+export function close(): boolean;


### PR DESCRIPTION
Even if you don't use typescript, some IDE's will still use the typings to help maintain Javascript.

These typings have been made blind, just going from your Readme.md
I have yet to get the project to run, but I needed to know how to actually run it, so I went to the effort to make the boiler plate.

I broke Exception out, even though it's only used once, just to make open function more readable.

If someone who know the return types from stuff like 'RequestData' callbacks or 'Subscribe' callbacks that will be most handy.
Or if the `value` going into `setDataOnSimObject` is always number? I suspect not, so I thrown string on there too, but again, advice.