### PR TITLE
Fixes on `requestSystemState` handler

### DIFF
--- a/src/addon.cc
+++ b/src/addon.cc
@@ -343,7 +343,7 @@ void handleReceived_SystemState(Isolate *isolate, SIMCONNECT_RECV *pData, DWORD 
 	Local<Object> obj = Object::New(isolate);
 	obj->Set(String::NewFromUtf8(isolate, "integer"), Number::New(isolate, pState->dwInteger));
 	obj->Set(String::NewFromUtf8(isolate, "float"), Number::New(isolate, pState->fFloat));
-	obj->Set(String::NewFromUtf8(isolate, "string"), String::NewFromUtf8(isolate, "string"));
+	obj->Set(String::NewFromUtf8(isolate, "string"), String::NewFromUtf8(isolate, pState->szString));
 
 	Local<Value> argv[1] = {obj};
 	systemStateCallbacks[pState->dwRequestID]->Call(isolate->GetCurrentContext()->Global(), 1, argv);

--- a/src/addon.cc
+++ b/src/addon.cc
@@ -346,7 +346,7 @@ void handleReceived_SystemState(Isolate *isolate, SIMCONNECT_RECV *pData, DWORD 
 	obj->Set(String::NewFromUtf8(isolate, "string"), String::NewFromUtf8(isolate, "string"));
 
 	Local<Value> argv[1] = {obj};
-	systemStateCallbacks[openEventId]->Call(isolate->GetCurrentContext()->Global(), 1, argv);
+	systemStateCallbacks[pState->dwRequestID]->Call(isolate->GetCurrentContext()->Global(), 1, argv);
 }
 
 void handleReceived_Quit(Isolate *isolate)


### PR DESCRIPTION
This pull request fixes two issues on the `handleReceived_SystemState` method:

1. The callback called when data is received is wrong, and it's an immediate crash on the node-js app when called. I'm not sure I understand why it was changed in https://github.com/EvenAR/node-simconnect/pull/7 as we should clearly call the callback set for the specific request we just made
2. [This commit](https://github.com/EvenAR/node-simconnect/commit/5daf903883eeb46998a60b8b1e045ad8ccb62250) introduced a hard coded value "string" on the system state returned object. I put it back to the actual string returned