### PR TITLE
Fix generateDataDefinition calling SimConnect method too many times

### DIFF
--- a/src/addon.cc
+++ b/src/addon.cc
@@ -672,48 +672,32 @@ DataDefinition generateDataDefinition(Isolate *isolate, HANDLE hSimConnect, Loca
 				}
 
 				SIMCONNECT_DATATYPE datumType = SIMCONNECT_DATATYPE_FLOAT64; // Default type (double)
-				double epsilon;
-				float datumId;
-
-				if (len > 1)
-				{
-					hr = SimConnect_AddToDataDefinition(hSimConnect, definitionId, sDatumName, sUnitsName);
-					if (NT_ERROR(hr))
-					{
-						handle_Error(isolate, hr);
-						break;
-					}
-				}
 				if (len > 2)
 				{
 					int t = value->Get(2)->Int32Value(ctx).ToChecked();
 					datumType = SIMCONNECT_DATATYPE(t);
-					hr = SimConnect_AddToDataDefinition(hSimConnect, definitionId, sDatumName, sUnitsName, datumType);
-					if (NT_ERROR(hr))
+					double epsilon = 0;
+					float datumId = SIMCONNECT_UNUSED;
+
+					if (len > 3)
 					{
-						handle_Error(isolate, hr);
-						break;
+						epsilon = value->Get(3)->Int32Value(ctx).ToChecked();
 					}
-				}
-				if (len > 3)
-				{
-					epsilon = value->Get(3)->Int32Value(ctx).ToChecked();
-					hr = SimConnect_AddToDataDefinition(hSimConnect, definitionId, sDatumName, sUnitsName, datumType, epsilon);
-					if (NT_ERROR(hr))
+					if (len > 4)
 					{
-						handle_Error(isolate, hr);
-						break;
+						datumId = value->Get(4)->Int32Value(ctx).ToChecked();
 					}
-				}
-				if (len > 4)
-				{
-					datumId = value->Get(4)->Int32Value(ctx).ToChecked();
+
 					hr = SimConnect_AddToDataDefinition(hSimConnect, definitionId, sDatumName, sUnitsName, datumType, epsilon, datumId);
-					if (NT_ERROR(hr))
-					{
-						handle_Error(isolate, hr);
-						break;
-					}
+				}
+				else {
+					hr = SimConnect_AddToDataDefinition(hSimConnect, definitionId, sDatumName, sUnitsName);
+				}
+
+				if (NT_ERROR(hr))
+				{
+					handle_Error(isolate, hr);
+					break;
 				}
 
 				std::string datumNameStr(sDatumName);

--- a/src/addon.cc
+++ b/src/addon.cc
@@ -676,23 +676,21 @@ DataDefinition generateDataDefinition(Isolate *isolate, HANDLE hSimConnect, Loca
 				{
 					int t = value->Get(2)->Int32Value(ctx).ToChecked();
 					datumType = SIMCONNECT_DATATYPE(t);
-					double epsilon = 0;
-					float datumId = SIMCONNECT_UNUSED;
-
-					if (len > 3)
-					{
-						epsilon = value->Get(3)->Int32Value(ctx).ToChecked();
-					}
-					if (len > 4)
-					{
-						datumId = value->Get(4)->Int32Value(ctx).ToChecked();
-					}
-
-					hr = SimConnect_AddToDataDefinition(hSimConnect, definitionId, sDatumName, sUnitsName, datumType, epsilon, datumId);
 				}
-				else {
-					hr = SimConnect_AddToDataDefinition(hSimConnect, definitionId, sDatumName, sUnitsName);
+
+				float epsilon = 0;
+				if (len > 3)
+				{
+				  epsilon = value->Get(3)->Int32Value(ctx).ToChecked();
 				}
+
+				DWORD datumId = SIMCONNECT_UNUSED;
+				if (len > 4)
+				{
+				  datumId = value->Get(4)->Int32Value(ctx).ToChecked();
+				}
+
+				hr = SimConnect_AddToDataDefinition(hSimConnect, definitionId, sDatumName, sUnitsName, datumType, epsilon, datumId);
 
 				if (NT_ERROR(hr))
 				{


### PR DESCRIPTION
This pull request fixes a crash happening when using more than 2 arguments on data definition generation.

I tried for hours to understand why this code caused a CTD in FS2020 for me:
```js
simConnect.requestDataOnSimObject([["TITLE", null, simConnect.datatype.STRINGV]], function(data) {
  console.log(data);
}, simConnect.objectId.USER, simConnect.period.ONCE);
```

I think the logic in `generateDataDefinition` is flawed, if we take the extreme case of having such a structure:
```js
["PLANE LATITUDE", null, simConnect.datatype.FLOAT64, 0, putAnIdHere]
```

The method will call `SimConnect_AddToDataDefinition` 4 times, and thus because those are chaining conditions and not exclusive one (by using `else if`). I used the opportunity to factor a bit the code and make it lighter to read IMO.

~We could go event further and call it only once, but I think the assumption that FLOAT64 is the default is false, all calling the method without arguments let `SimConnect` decide correctly the type returned instead, hence the special `if len > 2` condition.~ Fixed in second commit.

Let me know what you think!