### PR TITLE
Correcting index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,7 +8,7 @@ export class SimConnect {
     ): boolean;
 }
 
-export class Client {
+interface Client {
     name: string;
     version: string;
 


### PR DESCRIPTION
Yes, internally Client may be a class, but it is not something an external code has access to, so I have changed it to a interface.

for example
```ts
import { Client, SimConnect } from 'node-simconnect';
const sim = new SimConnect(); // valid
const client = new Client(); // invalid;
```
with it being an interface, this still allows us to do 
```ts
import { Client, SimConnect } from 'node-simconnect';
const sim = new SimConnect();
sim.open(
  ...,
  open,
  ...
  ...
);

function open(client: Client): void {
  ... blar blar
}
```

Again, I have done this blind.