### PR TITLE
Fix Registry error and handle connection timeout

### DIFF
--- a/src/SimConnectConnection.ts
+++ b/src/SimConnectConnection.ts
@@ -1096,6 +1096,10 @@ class SimConnectConnection extends EventEmitter {
     }
 
     close() {
+        if(this.openTimeout >= 0) {
+            clearTimeout(this.openTimeout);
+            this.openTimeout = -1;
+        }
         this.clientSocket.close();
     }
 

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -7,19 +7,22 @@ import * as os from 'os';
 import regedit = require('regedit');
 
 async function findSimConnectPortIPv4(): Promise<number> {
-    const port = await readRegistryValue('SimConnect_Port_IPv4');
-    return parseInt(port, 10);
+    try {
+        const port = await readRegistryValue('SimConnect_Port_IPv4');
+        return parseInt(port, 10);
+    } catch {
+        return 2048;
+    }
 }
 
 function readRegistryValue(subKey: string): Promise<string> {
     const FS_KEY =
         'HKCU\\Software\\Microsoft\\Microsoft Games\\Flight Simulator';
-    return new Promise<string>((resolve) => {
+    return new Promise<string>((resolve, reject) => {
         // eslint-disable-next-line
         regedit.list(FS_KEY, (err: any, result: any) => {
             if (err) {
-                console.error(`Failed to read registry value ${FS_KEY} (${err})`);
-                resolve('2048');
+                reject(`Failed to read registry value ${FS_KEY} (${err})`);
             } else {
                 resolve(result[FS_KEY].values[subKey].value);
             }

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -18,7 +18,8 @@ function readRegistryValue(subKey: string): Promise<string> {
         // eslint-disable-next-line
         regedit.list(FS_KEY, (err: any, result: any) => {
             if (err) {
-                throw Error(`Failed to read registry value ${FS_KEY} (${err})`);
+                console.error(`Failed to read registry value ${FS_KEY} (${err})`);
+                resolve('2048');
             } else {
                 resolve(result[FS_KEY].values[subKey].value);
             }


### PR DESCRIPTION
I took the liberty to offer a fix to Issue #46 and in the process also a handler for connection timeout.

In case the sim is still loading a PIPE will be available but no connect event will be thrown until open is received from SimConnect. Therefore if we reconnect too soon we will end up with multiple connections. This timeout prevents that and expects open signal within 5 seconds. If not then error is thrown which can be handled correctly and proper reconnect can happen.

Hope the code is suitable to be included into master.