### PR TITLE
Fix: undefined property access

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2495,9 +2495,9 @@
       "dev": true
     },
     "node_modules/decode-uri-component": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
       "dev": true,
       "engines": {
         "node": ">=0.10"
@@ -10941,9 +10941,9 @@
       "dev": true
     },
     "decode-uri-component": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
       "dev": true
     },
     "deep-is": {

--- a/src/connectionParameters.ts
+++ b/src/connectionParameters.ts
@@ -13,6 +13,9 @@ async function findSimConnectPortIPv4(): Promise<number> {
             'HKCU\\Software\\Microsoft\\Microsoft Games\\Flight Simulator',
             'SimConnect_Port_IPv4'
         );
+        if (!port) {
+            throw new Error('Could not find SimConnect_Port_IPv4 in the Windows registry');
+        }
         return parseInt(port, 10);
     } catch {
         return 2048;

--- a/src/utils/registry.ts
+++ b/src/utils/registry.ts
@@ -1,14 +1,18 @@
 // @ts-ignore // eslint-disable-line
 import regedit = require('regedit');
 
-export function readRegistryValue(FS_KEY: string, subKey: string): Promise<string> {
-    return new Promise<string>((resolve, reject) => {
+/**
+ * Returns `undefined` if the key does not exist.
+ */
+export function readRegistryValue(FS_KEY: string, subKey: string): Promise<string | undefined> {
+    return new Promise<string | undefined>((resolve, reject) => {
         // eslint-disable-next-line
         regedit.list(FS_KEY, (err: any, result: any) => {
             if (err) {
                 reject(new Error(`Failed to read registry value ${FS_KEY} (${err})`));
             } else {
-                resolve(result[FS_KEY].values[subKey].value);
+                const values: { [key: string]: any } = result[FS_KEY]?.values;
+                resolve(values ? values[subKey].value : undefined);
             }
         });
     });


### PR DESCRIPTION
I was running into an issue where, when the simulator was not running, I got the following error in the `utils/registry.ts` file at line 14:

```
TypeError: Cannot read properties of undefined (reading 'SimConnect_Port_IPv4')
```

This pull request resolves this issue by returning undefined if the key does not exist:

```ts
const values: { [key: string]: any } = result[FS_KEY]?.values;
resolve(values ? values[subKey].value : undefined);
```

I've also added `connectionParameters.ts` line 16-18 to handle cases where `undefined` is returned.