### PR TITLE
Fixed bug where region in facility list was lost

### DIFF
--- a/src/datastructures/FacilityAirport.ts
+++ b/src/datastructures/FacilityAirport.ts
@@ -3,6 +3,8 @@ import { RawBuffer } from '../RawBuffer';
 export class FacilityAirport {
     icao: string;
 
+    region: string;
+
     latitude: number;
 
     longitude: number;
@@ -10,7 +12,8 @@ export class FacilityAirport {
     altitude: number;
 
     constructor(data: RawBuffer) {
-        this.icao = data.readString(9);
+        this.icao = data.readString(6);
+        this.region = data.readString(3);
         this.latitude = data.readFloat64();
         this.longitude = data.readFloat64();
         this.altitude = data.readFloat64();


### PR DESCRIPTION
According to the doc (https://docs.flightsimulator.com/html/Programming_Tools/SimConnect/API_Reference/Structures_And_Enumerations/SIMCONNECT_DATA_FACILITY_AIRPORT.htm) the list items have two leading strings, ident with 6 bytes and region with 3.

When reading with "9", the region was ignored. I assume it's because there is a null-terminator at the end of the ICAO. So the resulting "icao" was correct before, but no region.

Example:
```
  FacilityVOR {
    icao: 'HST',
    region: 'K7',
    latitude: 25.489980429410934,
    longitude: -80.37941381335258,
    altitude: 0.9140000343322754,
    magVar: 6,
    frequency: 108200000,
    flags: 8,
    localizer: 0,
    glideLat: 0,
    glideLon: 0,
    glideAlt: 0,
    glideSlipeAngle: 0
  }
```

(Sorry for not creating an issue first, just happened to catch this when testing other stuff)