### PR TITLE
Use the bigint type instead of Long for event ID hashes

### DIFF
--- a/samples/typescript/inputEvents.ts
+++ b/samples/typescript/inputEvents.ts
@@ -9,7 +9,7 @@ open('My app', Protocol.KittyHawk)
 
         let allInputEvents: {
             inputEventName: string;
-            inputEventIdHash: string;
+            inputEventIdHash: bigint;
             params?: string;
         }[] = [];
 
@@ -17,7 +17,7 @@ open('My app', Protocol.KittyHawk)
             recvEnumerateInputEvents.inputEventDescriptors.forEach(e => {
                 allInputEvents.push({
                     inputEventName: e.name,
-                    inputEventIdHash: e.inputEventIdHash.toString(),
+                    inputEventIdHash: e.inputEventIdHash,
                 });
                 handle.enumerateInputEventParams(e.inputEventIdHash);
             });
@@ -27,8 +27,7 @@ open('My app', Protocol.KittyHawk)
             // Update the list with the received value
             allInputEvents = allInputEvents.map(inputEvent => {
                 if (
-                    inputEvent.inputEventIdHash ===
-                    recvEnumerateInputEventParams.inputEventIdHash.toString()
+                    inputEvent.inputEventIdHash === recvEnumerateInputEventParams.inputEventIdHash
                 ) {
                     return { ...inputEvent, params: recvEnumerateInputEventParams.value };
                 } else {

--- a/src/RawBuffer.ts
+++ b/src/RawBuffer.ts
@@ -71,8 +71,8 @@ class RawBuffer {
         return this.buffer.readInt64().toNumber();
     }
 
-    readUint64(): Long {
-        return this.buffer.readUint64();
+    readUint64(): bigint {
+        return BigInt(this.buffer.readUint64().toString(10));
     }
 
     /** @deprecated use readInt64() instead */
@@ -86,8 +86,10 @@ class RawBuffer {
         this.buffer.writeUint64(value, offset);
     }
 
-    writeUint64(value: Long, offset?: number) {
-        this.buffer.writeUint64(value, offset);
+    writeUint64(value: bigint, offset?: number) {
+        const buffer = Buffer.alloc(8);
+        buffer.writeBigUint64LE(value);
+        this.buffer.append(buffer, undefined, offset);
     }
 
     /** @deprecated use writeInt64() instead */

--- a/src/SimConnectConnection.ts
+++ b/src/SimConnectConnection.ts
@@ -1596,7 +1596,7 @@ class SimConnectConnection extends EventEmitter {
      *
      * @returns sendId of packet (can be used to identify packet when exception event occurs)
      */
-    getInputEvent(dataRequestID: number, inputEventHashID: Long): number {
+    getInputEvent(dataRequestID: number, inputEventHashID: bigint): number {
         if (this._ourProtocol < Protocol.KittyHawk) throw Error(SimConnectError.BadVersion);
 
         const packet = this._beginPacket(0x50).putInt32(dataRequestID).putUint64(inputEventHashID);
@@ -1607,7 +1607,7 @@ class SimConnectConnection extends EventEmitter {
      *
      * @returns sendId of packet (can be used to identify packet when exception event occurs)
      */
-    setInputEvent(inputEventHashID: Long, value: number | string): number {
+    setInputEvent(inputEventHashID: bigint, value: number | string): number {
         if (this._ourProtocol < Protocol.KittyHawk) throw Error(SimConnectError.BadVersion);
 
         const packet = this._beginPacket(0x51).putUint64(inputEventHashID);
@@ -1625,7 +1625,7 @@ class SimConnectConnection extends EventEmitter {
      *
      * @returns sendId of packet (can be used to identify packet when exception event occurs)
      */
-    subscribeInputEvent(inputEventHashID: Long): number {
+    subscribeInputEvent(inputEventHashID: bigint): number {
         if (this._ourProtocol < Protocol.KittyHawk) throw Error(SimConnectError.BadVersion);
 
         return this._buildAndSend(this._beginPacket(0x52).putUint64(inputEventHashID));
@@ -1635,7 +1635,7 @@ class SimConnectConnection extends EventEmitter {
      *
      * @returns sendId of packet (can be used to identify packet when exception event occurs)
      */
-    unsubscribeInputEvent(inputEventHashID: Long): number {
+    unsubscribeInputEvent(inputEventHashID: bigint): number {
         if (this._ourProtocol < Protocol.KittyHawk) throw Error(SimConnectError.BadVersion);
 
         return this._buildAndSend(this._beginPacket(0x53).putUint64(inputEventHashID));
@@ -1645,7 +1645,7 @@ class SimConnectConnection extends EventEmitter {
      *
      * @returns sendId of packet (can be used to identify packet when exception event occurs)
      */
-    enumerateInputEventParams(inputEventHashID: Long): number {
+    enumerateInputEventParams(inputEventHashID: bigint): number {
         if (this._ourProtocol < Protocol.KittyHawk) throw Error(SimConnectError.BadVersion);
 
         return this._buildAndSend(this._beginPacket(0x54).putUint64(inputEventHashID));

--- a/src/SimConnectPacketBuilder.ts
+++ b/src/SimConnectPacketBuilder.ts
@@ -54,7 +54,7 @@ export class SimConnectPacketBuilder {
         return this;
     }
 
-    putUint64(value: Long, offset?: number) {
+    putUint64(value: bigint, offset?: number) {
         this.packetContent.writeUint64(value, offset);
         return this;
     }

--- a/src/datastructures/InputEventDescriptor.ts
+++ b/src/datastructures/InputEventDescriptor.ts
@@ -4,7 +4,7 @@ import { RawBuffer } from '../RawBuffer';
 export class InputEventDescriptor {
     name: string;
 
-    inputEventIdHash: Long;
+    inputEventIdHash: bigint;
 
     type: InputEventType;
 

--- a/src/recv/RecvEnumerateInputEventParams.ts
+++ b/src/recv/RecvEnumerateInputEventParams.ts
@@ -1,7 +1,7 @@
 import { RawBuffer } from '../RawBuffer';
 
 export class RecvEnumerateInputEventParams {
-    inputEventIdHash: Long;
+    inputEventIdHash: bigint;
 
     value: string;
 

--- a/src/recv/RecvSubscribeInputEvent.ts
+++ b/src/recv/RecvSubscribeInputEvent.ts
@@ -2,7 +2,7 @@ import { RawBuffer } from '../RawBuffer';
 import { InputEventType } from '../enums/InputEventType';
 
 export class RecvSubscribeInputEvent {
-    inputEventIdHash: Long;
+    inputEventIdHash: bigint;
 
     type: InputEventType;
 


### PR DESCRIPTION
Long is a non-standard type used by bytebuffer package. The bigint will be converted to Long in the RawBuffer class (bytebuffer wrapper), but the node-simconnect users won't have to worry about it anymore.

This is a breaking change. Solves #107