### PR TITLE
Encode/decode strings with win1252

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@types/node": "*",
         "bytebuffer": "^5.0.1",
         "debug": "^4.3.4",
+        "iconv-lite": "^0.7.0",
         "ini": "^2.0.0",
         "regedit": "^5.1.1"
       },
@@ -3537,6 +3538,22 @@
         "url": "https://github.com/sponsors/typicode"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
+      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/if-async": {
       "version": "3.7.4",
       "resolved": "https://registry.npmjs.org/if-async/-/if-async-3.7.4.tgz",
@@ -5778,6 +5795,12 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
       "dev": true
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "6.3.0",
@@ -9193,6 +9216,14 @@
       "integrity": "sha512-xs7/chUH/CKdOCs7Zy0Aev9e/dKOMZf3K1Az1nar3tzlv0jfqnYtu235bstsWTmXOR0EfINrPa97yy4Lz6RiKw==",
       "dev": true
     },
+    "iconv-lite": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
+      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      }
+    },
     "if-async": {
       "version": "3.7.4",
       "resolved": "https://registry.npmjs.org/if-async/-/if-async-3.7.4.tgz",
@@ -10829,6 +10860,11 @@
           "dev": true
         }
       }
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "semver": {
       "version": "6.3.0",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@types/node": "*",
     "bytebuffer": "^5.0.1",
     "debug": "^4.3.4",
+    "iconv-lite": "^0.7.0",
     "ini": "^2.0.0",
     "regedit": "^5.1.1"
   },

--- a/src/RawBuffer.ts
+++ b/src/RawBuffer.ts
@@ -1,3 +1,4 @@
+import iconv = require('iconv-lite');
 import ByteBuffer = require('bytebuffer');
 
 class RawBuffer {
@@ -208,14 +209,15 @@ class RawBuffer {
 }
 
 function makeString(bf: ByteBuffer, expectedLength: number) {
-    const content = bf.readCString(bf.offset);
-    bf.skip(expectedLength);
-    return content.string;
+    const bytes = bf.readBytes(expectedLength).toBuffer();
+    const nullIndex = bytes.indexOf(0);
+    const end = nullIndex === -1 ? expectedLength : nullIndex;
+    return iconv.decode(bytes.subarray(0, end), 'win1252');
 }
 
 function putString(bf: ByteBuffer, s: string | null, fixed: number) {
     const value = s === null ? '' : s;
-    const bytes = Buffer.from(value, 'utf-8');
+    const bytes = iconv.encode(value, 'win1252');
     bf.append(bytes);
     if (bytes.length < fixed) {
         for (let i = 0; i < fixed - bytes.length; i++) {


### PR DESCRIPTION
Currently, the `putString` and `makeString` functions in the buffer utilities file treat the string as a UTF-8 encoded string. However, SimConnect uses Windows-1252 encoding. We noticed this issue when inspecting the `RecvOpen` details of a P3D connection; the string was read as `Lockheed Martin� Prepar3D� v6`. With this fix, the string reads properly.